### PR TITLE
Fix unused slack_webhook_url causing error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -240,7 +240,7 @@ resource "aws_kms_key" "this" {
 }
 
 resource "aws_kms_ciphertext" "slack_url" {
-  count     = var.cloudwatch_metric_alarms_enabled ? 1 : 0
+  count     = var.slack_notification_enabled && var.cloudwatch_metric_alarms_enabled ? 1 : 0
   plaintext = var.slack_webhook_url
   key_id    = aws_kms_key.this[0].arn
 }


### PR DESCRIPTION
I used `slack_notification_enabled       = false` and was not supplying a `slack_webhook_url`. This resulted in the following error:

```
│ Error: encrypting with KMS Key (arn:aws:kms:us-xxxx-x:xxxx:key/xxxx-xxxx-xxxx-xxxx-xxxxxxx): InvalidParameter: 1 validation error(s) found.
│ - minimum field size of 1, EncryptInput.Plaintext.
│
│
│   with module.xxxx.module.xxxx.module.rds-pg.aws_kms_ciphertext.slack_url[0],
│   on .terraform/modules/xxxx.database.rds-pg/main.tf line 242, in resource "aws_kms_ciphertext" "slack_url":
│  242: resource "aws_kms_ciphertext" "slack_url" {
│
```